### PR TITLE
Fix rebalancing with rounding errors

### DIFF
--- a/app/controllers/timer_sessions_controller.rb
+++ b/app/controllers/timer_sessions_controller.rb
@@ -5,7 +5,7 @@ class TimerSessionsController < TrackyController
     @timer_sessions_in_range = TimerSession.includes(:issues, :time_entries, :timer_session_time_entries)
                                            .finished
                                            .created_by(@current_user)
-    @non_matching_timer_session_ids = TimeDiscrepancyLoader.uneven_timer_sessions(@timer_sessions_in_range).map(&:id)
+    @non_matching_timer_session_ids = TimeDiscrepancyLoader.uneven_timer_sessions(@timer_sessions_in_range).ids
     set_timer_sessions
     @timer_offset = offset_for_time_zone
   end

--- a/app/controllers/timer_sessions_controller.rb
+++ b/app/controllers/timer_sessions_controller.rb
@@ -5,15 +5,8 @@ class TimerSessionsController < TrackyController
     @timer_sessions_in_range = TimerSession.includes(:issues, :time_entries, :timer_session_time_entries)
                                            .finished
                                            .created_by(@current_user)
-    @non_matching_timer_session_ids = TimeDiscrepancyLoader.uneven_timer_sessions(@timer_sessions_in_range).pluck(:id)
-    @timer_sessions = apply_filter(@timer_sessions_in_range, :timer_start)
-    time_entries = time_entries_in_range(@timer_sessions)
-
-    @timer_sessions = (@timer_sessions.order(timer_start: :desc) + time_entries)
-                      .map { |time_entity| TimeEntityDecorator.new(time_entity) }
-                      .sort_by(&:start_time)
-                      .reverse
-                      .group_by(&:entry_date)
+    @non_matching_timer_session_ids = TimeDiscrepancyLoader.uneven_timer_sessions(@timer_sessions_in_range).map(&:id)
+    set_timer_sessions
     @timer_offset = offset_for_time_zone
   end
 
@@ -81,6 +74,16 @@ class TimerSessionsController < TrackyController
   end
 
   private
+
+  def set_timer_sessions
+    @timer_sessions = apply_filter(@timer_sessions_in_range, :timer_start)
+    time_entries = time_entries_in_range(@timer_sessions)
+    @timer_sessions = (@timer_sessions.order(timer_start: :desc) + time_entries)
+                      .map { |time_entity| TimeEntityDecorator.new(time_entity) }
+                      .sort_by(&:start_time)
+                      .reverse
+                      .group_by(&:entry_date)
+  end
 
   def apply_filter(timer_sessions, column)
     @filter = Filtering::TimerSessionsFilter.new(filter_params.merge(filter_column: column))

--- a/app/services/time_discrepancy_loader.rb
+++ b/app/services/time_discrepancy_loader.rb
@@ -5,22 +5,19 @@ class TimeDiscrepancyLoader
 
   # `scope` is an AR collection proxy for TimerSession
   def self.uneven_timer_sessions(scope)
-    scope.joins(:time_entries)
-         .group(:id, :timer_start, :timer_end)
+    scope.joins(timer_session_time_entries: :time_entry)
+         .group('timer_sessions.id')
          .having(
            <<~SQL
-             CAST(SUM(time_entries.hours)
-             AS DECIMAL(10, #{DECIMALS_TO_ROUND_TO}))
-             !=
-             CAST((#{time_difference_expr}) / 3600.0
-             AS DECIMAL(10, #{DECIMALS_TO_ROUND_TO}))
+             timer_sessions.hours != CAST(SUM(time_entries.hours) AS DECIMAL(10, #{DECIMALS_TO_ROUND_TO}))
+             OR timer_sessions.hours != #{time_difference_expr} / 3600
            SQL
          )
   end
 
   def self.time_difference_expr
     if using_postgresql?
-      'EXTRACT(EPOCH FROM timer_sessions.timer_end) - EXTRACT(EPOCH FROM timer_sessions.timer_start)'
+      '(EXTRACT(EPOCH FROM timer_sessions.timer_end) - EXTRACT(EPOCH FROM timer_sessions.timer_start))'
     else
       'TIMESTAMPDIFF(SECOND, timer_sessions.timer_start, timer_sessions.timer_end)'
     end

--- a/test/factories/timer_session.rb
+++ b/test/factories/timer_session.rb
@@ -10,19 +10,22 @@ FactoryBot.define do
 
     trait :with_issues do
       after(:create) do |timer_session|
-        TimerSessionIssue.create!(
-          timer_session: timer_session,
-          issue: Issue.first
-        )
+        TimerSessionIssue.create!(timer_session:, issue: Issue.first)
       end
     end
 
     trait :with_time_entries do
       after(:create) do |timer_session|
-        TimerSessionTimeEntry.create!(
-          timer_session: timer_session,
-          time_entry: TimeEntry.first
-        )
+        TimerSessionTimeEntry.create!(timer_session:, time_entry: TimeEntry.first)
+      end
+    end
+
+    trait :with_unrounded_time_entries do
+      after(:create) do |timer_session|
+        3.times do
+          e = TimeEntry.create(user: User.current, project: Project.last, hours: 1.0 / 3, spent_on: Time.zone.today)
+          TimerSessionTimeEntry.create!(timer_session:, time_entry: e)
+        end
       end
     end
   end

--- a/test/unit/time_discrepancy_loader_test.rb
+++ b/test/unit/time_discrepancy_loader_test.rb
@@ -54,17 +54,4 @@ class TimeDiscrepancyLoaderTest < ActiveSupport::TestCase
     assert_equal 1, where_time_not_adding_up.length
     assert_kind_of TimerSession, where_time_not_adding_up.first
   end
-
-  test 'round hours in timer session' do
-    assert_equal @timer_session.time_entries.sum(&:hours), 0.99
-    assert_equal @timer_session.hours, 1 # instead of 0.99
-  end
-
-  test 'ignore small discrepancies in time sum' do
-    timer_sessions_in_range = TimerSession.includes(:issues, :time_entries, :timer_session_time_entries)
-                                          .finished.created_by(User.current)
-    non_matching_timer_sessions = TimeDiscrepancyLoader.uneven_timer_sessions(timer_sessions_in_range)
-
-    assert non_matching_timer_sessions.ids.exclude?(@timer_session.id)
-  end
 end

--- a/test/unit/time_discrepancy_loader_test.rb
+++ b/test/unit/time_discrepancy_loader_test.rb
@@ -45,4 +45,13 @@ class TimeDiscrepancyLoaderTest < ActiveSupport::TestCase
     assert_equal 1, where_time_not_adding_up.length
     assert_kind_of TimerSession, where_time_not_adding_up.first
   end
+
+  test 'ignore small discrepancies in time sum' do
+    timer_session = FactoryBot.create_list(:timer_session, 1, :with_unrounded_time_entries, user: User.current).first
+    timer_sessions_in_range = TimerSession.includes(:issues, :time_entries, :timer_session_time_entries)
+                                          .finished.created_by(User.current)
+    non_matching_timer_session_ids = TimeDiscrepancyLoader.uneven_timer_sessions(timer_sessions_in_range).map(&:id)
+
+    assert non_matching_timer_session_ids.exclude?(timer_session.id)
+  end
 end

--- a/test/unit/time_discrepancy_loader_test.rb
+++ b/test/unit/time_discrepancy_loader_test.rb
@@ -63,8 +63,8 @@ class TimeDiscrepancyLoaderTest < ActiveSupport::TestCase
   test 'ignore small discrepancies in time sum' do
     timer_sessions_in_range = TimerSession.includes(:issues, :time_entries, :timer_session_time_entries)
                                           .finished.created_by(User.current)
-    non_matching_timer_session_ids = TimeDiscrepancyLoader.uneven_timer_sessions(timer_sessions_in_range).map(&:id)
+    non_matching_timer_sessions = TimeDiscrepancyLoader.uneven_timer_sessions(timer_sessions_in_range)
 
-    assert non_matching_timer_session_ids.exclude?(@timer_session.id)
+    assert non_matching_timer_sessions.ids.exclude?(@timer_session.id)
   end
 end


### PR DESCRIPTION
TICKET-19655
Rebalancing can produce unfixable mismatch between timer session and time entries.
For example if you start a timer session with 1h on three tickets, then clicking "Ausbalancieren" will not work.

* Fix these rounding errors