### PR TITLE
Hide timer cancel button

### DIFF
--- a/app/views/timer_sessions/_timer_container.html.erb
+++ b/app/views/timer_sessions/_timer_container.html.erb
@@ -93,6 +93,6 @@
       <% end %>
     <% end %>
 
-    <%= button_to "hide me", time_tracker_path, method: :delete, form: {id: "timer-cancel-form", data: {remote: true}, format: "js"} %>
+    <%= button_to "", time_tracker_path, class: "hidden", method: :delete, form: {id: "timer-cancel-form", data: {remote: true}, format: "js"} %>
   </div>
 </div>


### PR DESCRIPTION
TICKET-19656

Apply `hidden` to hidden button.

## QA

Why does this button exist?

1. The cancel button belongs to a different action.
2. Forms cannot be nested.
3. Updating the form action based off the submit button value is challenging and error prone.
4. It was easy to add it.


<details>
<summary>Before</summary>

![CleanShot 2024-07-03 at 10 41 56@2x](https://github.com/renuo/redmine_tracky/assets/53896675/defb1ebf-685b-4246-bc7f-ab4dcecaa5b7)

</details>

<details>
<summary>After</summary>


![CleanShot 2024-07-03 at 10 42 16@2x](https://github.com/renuo/redmine_tracky/assets/53896675/4e646948-1618-4c3d-b286-88765e4687d0)


</details>