### PR TITLE
Fix timer stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,44 @@ Administration => Roles & Permissions
 - Test: `rake test`
 - Watch Assets: `rake watch`
 
+## Time Tracking Flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> CheckingSession : Start Request
+    
+    CheckingSession --> Conflict : Session Exists
+    Conflict --> [*] : Return Conflict
+    
+    CheckingSession --> SessionCreation : No Active Session
+    SessionCreation --> ValidatingSession : Create Session
+    
+    ValidatingSession --> IssueAssociation : Valid Session
+    ValidatingSession --> Error : Invalid Session
+    Error --> [*] : Return Unprocessable
+    
+    IssueAssociation --> ConnectorValidation : Issue Connector Init
+    ConnectorValidation --> Error : Connector Invalid
+    Error --> [*] : Return Unprocessable
+    
+    ConnectorValidation --> CheckingFinished : Connector Valid
+    CheckingFinished --> Finalize : Session Finished
+    CheckingFinished --> UpdateTimer : Session Active
+    
+    Finalize --> TimeEntryCreation : Mark Finished
+    TimeEntryCreation --> Success : Create Time Entries
+    Success --> [*] : Return Success
+    
+    UpdateTimer --> TimerUpdated : Update Session
+    TimerUpdated --> Success : Valid Update
+    TimerUpdated --> Error : Invalid Update
+    Error --> [*] : Return Unprocessable
+    
+    destroy : Destroy Session
+    destroy --> Cancel : Cancel Timer
+    Cancel --> [*] : Return Cancel
+```
+
 ## Copyright
 
 Copyright 2021-2024 [Renuo AG](https://www.renuo.ch/), published under the MIT license.

--- a/app/controllers/time_tracker_controller.rb
+++ b/app/controllers/time_tracker_controller.rb
@@ -37,6 +37,10 @@ class TimeTrackerController < TrackyController
   end
 
   def update
+    unless timer_params["timer_end"].present?
+      timer_params = timer_params.merge("timer_end" => Time.zone.now)
+    end
+
     return render_js(:update, :unprocessable_entity) unless @current_timer_session.update(timer_params)
 
     if @current_timer_session.session_finished?

--- a/app/controllers/time_tracker_controller.rb
+++ b/app/controllers/time_tracker_controller.rb
@@ -39,9 +39,7 @@ class TimeTrackerController < TrackyController
   def update
     updated_params = timer_params
 
-    if updated_params[:timer_end].blank?
-      updated_params[:timer_end] = user_time_zone.now.asctime
-    end
+    updated_params[:timer_end] = user_time_zone.now.asctime if updated_params[:timer_end].blank?
 
     return render_js(:update, :unprocessable_entity) unless @current_timer_session.update(updated_params)
 

--- a/app/controllers/time_tracker_controller.rb
+++ b/app/controllers/time_tracker_controller.rb
@@ -37,11 +37,13 @@ class TimeTrackerController < TrackyController
   end
 
   def update
-    unless timer_params["timer_end"].present?
-      timer_params = timer_params.merge("timer_end" => Time.zone.now)
+    updated_params = timer_params
+
+    if updated_params[:timer_end].blank?
+      updated_params[:timer_end] = Time.zone.now
     end
 
-    return render_js(:update, :unprocessable_entity) unless @current_timer_session.update(timer_params)
+    return render_js(:update, :unprocessable_entity) unless @current_timer_session.update(updated_params)
 
     if @current_timer_session.session_finished?
       return render_js(:update, :unprocessable_entity) unless @current_timer_session.update(finished: true)

--- a/app/controllers/time_tracker_controller.rb
+++ b/app/controllers/time_tracker_controller.rb
@@ -40,7 +40,7 @@ class TimeTrackerController < TrackyController
     updated_params = timer_params
 
     if updated_params[:timer_end].blank?
-      updated_params[:timer_end] = Time.zone.now
+      updated_params[:timer_end] = user_time_zone.now.asctime
     end
 
     return render_js(:update, :unprocessable_entity) unless @current_timer_session.update(updated_params)

--- a/test/functional/time_tracker_controller_test.rb
+++ b/test/functional/time_tracker_controller_test.rb
@@ -132,6 +132,7 @@ class TimeTrackerControllerTest < ActionController::TestCase
       issue_ids: ['1']
     } }, xhr: true
     assert_response 200
+    assert_equal TimerSession.last.finished, true
   end
 
   test '#update - with no end time' do


### PR DESCRIPTION
This PR addresses the tracky issue where stopping a timer session with empty end_time would not finish the session.

## Todo
- [ ] Drop 5de0f89007efb4b6a262552ebcd080dd74012818 if not deemed useful @schmijos.