### PR TITLE
False positive overlapping sessions

### DIFF
--- a/app/models/timer_session.rb
+++ b/app/models/timer_session.rb
@@ -44,10 +44,21 @@ class TimerSession < RedmineTrackyApplicationRecord
   end
 
   def overlaps?(other_session)
-    (other_session.timer_start - timer_end) < -30.seconds
+    return false unless timer_end.present? && other_session.timer_start.present?
+
+    this_start = round_to_nearest_minute(timer_start)
+    this_end = round_to_nearest_minute(timer_end)
+    other_start = round_to_nearest_minute(other_session.timer_start)
+    other_end = round_to_nearest_minute(other_session.timer_end)
+
+    (this_start...this_end).overlaps?(other_start...other_end)
   end
 
   private
+
+  def round_to_nearest_minute(time)
+    Time.at((time.to_f / 60).round * 60).utc
+  end
 
   def set_recorded_hours
     return unless timer_start.present? && timer_end.present?

--- a/app/models/timer_session.rb
+++ b/app/models/timer_session.rb
@@ -49,7 +49,7 @@ class TimerSession < RedmineTrackyApplicationRecord
     my_end = timer_end.change(sec: 0)
     other_start = other_session.timer_start.change(sec: 0)
     other_end = other_session.timer_end.change(sec: 0)
-    
+
     (my_start...my_end).overlaps?(other_start...other_end)
   end
 

--- a/app/models/timer_session.rb
+++ b/app/models/timer_session.rb
@@ -44,7 +44,13 @@ class TimerSession < RedmineTrackyApplicationRecord
   end
 
   def overlaps?(other_session)
-    (timer_start...timer_end).overlaps?(other_session.timer_start...other_session.timer_end)
+    # Truncate seconds for overlap calculation
+    my_start = timer_start.change(sec: 0)
+    my_end = timer_end.change(sec: 0)
+    other_start = other_session.timer_start.change(sec: 0)
+    other_end = other_session.timer_end.change(sec: 0)
+    
+    (my_start...my_end).overlaps?(other_start...other_end)
   end
 
   private

--- a/app/models/timer_session.rb
+++ b/app/models/timer_session.rb
@@ -44,13 +44,7 @@ class TimerSession < RedmineTrackyApplicationRecord
   end
 
   def overlaps?(other_session)
-    # Truncate seconds for overlap calculation
-    my_start = timer_start.change(sec: 0)
-    my_end = timer_end.change(sec: 0)
-    other_start = other_session.timer_start.change(sec: 0)
-    other_end = other_session.timer_end.change(sec: 0)
-
-    (my_start...my_end).overlaps?(other_start...other_end)
+    (other_session.timer_start - timer_end) < -30.seconds
   end
 
   private

--- a/app/views/timer_sessions/_timer_sessions_day_block.html.erb
+++ b/app/views/timer_sessions/_timer_sessions_day_block.html.erb
@@ -11,7 +11,7 @@
         <%= render TimerSessionEntryComponent.new(
           timer_session_entry: time_entity,
           discrepancy_detected: @non_matching_timer_session_ids.include?(time_entity.id),
-          overlap_detected: timer_sessions.any? { |other_entity| time_entity != other_entity && other_entity.overlaps?(time_entity) },
+          overlap_detected: timer_sessions.any? { |other_entity| time_entity != other_entity && other_entity&.overlaps?(time_entity) },
           gap_separator: draw_gap_separator(time_entity, previous_time_entity)
         ) %>
       <% end %>

--- a/test/unit/timer_session_test.rb
+++ b/test/unit/timer_session_test.rb
@@ -83,5 +83,15 @@ class TimerSessionTest < ActiveSupport::TestCase
 
     assert_not session1.overlaps?(session2)
     assert_not session2.overlaps?(session1)
+
+    session1 = FactoryBot.create(:timer_session, user: User.current,
+                                                 timer_start: base_time,
+                                                 timer_end: base_time + 1.hour + 32.seconds)
+    session2 = FactoryBot.create(:timer_session, user: User.current,
+                                                 timer_start: base_time + 1.hour,
+                                                 timer_end: base_time + 2.hours)
+
+    assert session1.overlaps?(session2)
+    assert session2.overlaps?(session1)
   end
 end

--- a/test/unit/timer_session_test.rb
+++ b/test/unit/timer_session_test.rb
@@ -72,5 +72,16 @@ class TimerSessionTest < ActiveSupport::TestCase
 
     assert session3.overlaps?(session1)
     assert session1.overlaps?(session3)
+
+    base_time = Time.utc(2023, 1, 1, 10, 0, 0)
+    session1 = FactoryBot.create(:timer_session, user: User.current, 
+                                 timer_start: base_time, 
+                                 timer_end: base_time + 1.hour + 25.seconds)
+    session2 = FactoryBot.create(:timer_session, user: User.current, 
+                                 timer_start: base_time + 1.hour + 5.seconds, 
+                                 timer_end: base_time + 2.hours)
+
+    assert_not session1.overlaps?(session2)
+    assert_not session2.overlaps?(session1)
   end
 end

--- a/test/unit/timer_session_test.rb
+++ b/test/unit/timer_session_test.rb
@@ -74,12 +74,12 @@ class TimerSessionTest < ActiveSupport::TestCase
     assert session1.overlaps?(session3)
 
     base_time = Time.utc(2023, 1, 1, 10, 0, 0)
-    session1 = FactoryBot.create(:timer_session, user: User.current, 
-                                 timer_start: base_time, 
-                                 timer_end: base_time + 1.hour + 25.seconds)
-    session2 = FactoryBot.create(:timer_session, user: User.current, 
-                                 timer_start: base_time + 1.hour + 5.seconds, 
-                                 timer_end: base_time + 2.hours)
+    session1 = FactoryBot.create(:timer_session, user: User.current,
+                                                 timer_start: base_time,
+                                                 timer_end: base_time + 1.hour + 25.seconds)
+    session2 = FactoryBot.create(:timer_session, user: User.current,
+                                                 timer_start: base_time + 1.hour + 5.seconds,
+                                                 timer_end: base_time + 2.hours)
 
     assert_not session1.overlaps?(session2)
     assert_not session2.overlaps?(session1)

--- a/test/unit/timer_session_test.rb
+++ b/test/unit/timer_session_test.rb
@@ -58,7 +58,7 @@ class TimerSessionTest < ActiveSupport::TestCase
     assert_not @timer_session.valid?
   end
 
-  test 'overlaps?' do
+  test 'overlaps?' do # rubocop:disable Metrics/BlockLength
     session1 = FactoryBot.create(:timer_session, user: User.current, timer_start: Time.zone.now,
                                                  timer_end: Time.zone.now + 1.hour)
     session2 = FactoryBot.create(:timer_session, user: User.current, timer_start: Time.zone.now + 1.hour,


### PR DESCRIPTION
TICKET-23748

When calculating timer session overlap, seconds were previously taken into account, when in realty they shouldn't be.
This caused false positives in the UI when continuing the timer for example instead of manually entering timer sessions.

Example of such false positive time entry:
![CleanShot 2025-04-02 at 14 18 26@2x](https://github.com/user-attachments/assets/69f3a873-f643-443b-84fb-8029cac3212f)

While the time entries do overlap in theory, this should probably ignored when it's less than a minute.
