### PR TITLE
Fix param reset

### DIFF
--- a/app/views/time_tracker/cancel.js.erb
+++ b/app/views/time_tracker/cancel.js.erb
@@ -1,1 +1,1 @@
-window.location.href='<%= timer_sessions_path %>';
+window.location.href = '<%= timer_sessions_path %>' + window.location.search;

--- a/app/views/time_tracker/stop.js.erb
+++ b/app/views/time_tracker/stop.js.erb
@@ -1,1 +1,1 @@
-window.location.href='<%= timer_sessions_path %>';
+window.location.href = '<%= timer_sessions_path %>' + window.location.search;

--- a/app/views/timer_sessions/update_redirect.js.erb
+++ b/app/views/timer_sessions/update_redirect.js.erb
@@ -1,1 +1,1 @@
-window.location.href='<%= timer_sessions_path %>';
+window.location.href = '<%= timer_sessions_path %>' + window.location.search;

--- a/test/system/timer_management_test.rb
+++ b/test/system/timer_management_test.rb
@@ -111,23 +111,23 @@ class TimerManagementTest < ApplicationSystemTestCase
     assert has_content?(Issue.first.subject, wait: 5)
     assert has_content?(Issue.second.subject)
   end
-  
+
   test 'preserves filter parameters when stopping a timer' do
     filter_date = 1.week.ago.strftime('%Y-%m-%d')
     current_date = Date.today.strftime('%Y-%m-%d')
-    
+
     visit timer_sessions_path(filter: { min_date: filter_date, max_date: current_date })
-    
+
     find('[data-name="timer-start"]').click
     assert has_content?(I18n.t('timer_sessions.timer.stop'))
-    
+
     fill_in 'timer_session[issue_id]', with: Issue.first.subject
     sleep(1)
     find('#timer_session_issue_id').send_keys(:arrow_down)
     find('#timer_session_issue_id').send_keys(:tab)
-    
+
     find('[data-name="timer-stop"]', wait: 5).click
-    
+
     assert current_url.include?("filter%5Bmin_date%5D=#{filter_date}")
     assert current_url.include?("filter%5Bmax_date%5D=#{current_date}")
   end
@@ -135,15 +135,15 @@ class TimerManagementTest < ApplicationSystemTestCase
   test 'preserves filter parameters when canceling a timer' do
     filter_date = 1.week.ago.strftime('%Y-%m-%d')
     current_date = Date.today.strftime('%Y-%m-%d')
-    
+
     visit timer_sessions_path(filter: { min_date: filter_date, max_date: current_date })
-    
+
     find('[data-name="timer-start"]').click
     assert has_content?(I18n.t('timer_sessions.timer.cancel'))
-    
+
     find('[data-name="timer-cancel"]', wait: 5).click
     page.driver.browser.switch_to.alert.accept
-    
+
     assert current_url.include?("filter%5Bmin_date%5D=#{filter_date}")
     assert current_url.include?("filter%5Bmax_date%5D=#{current_date}")
   end

--- a/test/system/timer_management_test.rb
+++ b/test/system/timer_management_test.rb
@@ -111,4 +111,40 @@ class TimerManagementTest < ApplicationSystemTestCase
     assert has_content?(Issue.first.subject, wait: 5)
     assert has_content?(Issue.second.subject)
   end
+  
+  test 'preserves filter parameters when stopping a timer' do
+    filter_date = 1.week.ago.strftime('%Y-%m-%d')
+    current_date = Date.today.strftime('%Y-%m-%d')
+    
+    visit timer_sessions_path(filter: { min_date: filter_date, max_date: current_date })
+    
+    find('[data-name="timer-start"]').click
+    assert has_content?(I18n.t('timer_sessions.timer.stop'))
+    
+    fill_in 'timer_session[issue_id]', with: Issue.first.subject
+    sleep(1)
+    find('#timer_session_issue_id').send_keys(:arrow_down)
+    find('#timer_session_issue_id').send_keys(:tab)
+    
+    find('[data-name="timer-stop"]', wait: 5).click
+    
+    assert current_url.include?("filter%5Bmin_date%5D=#{filter_date}")
+    assert current_url.include?("filter%5Bmax_date%5D=#{current_date}")
+  end
+
+  test 'preserves filter parameters when canceling a timer' do
+    filter_date = 1.week.ago.strftime('%Y-%m-%d')
+    current_date = Date.today.strftime('%Y-%m-%d')
+    
+    visit timer_sessions_path(filter: { min_date: filter_date, max_date: current_date })
+    
+    find('[data-name="timer-start"]').click
+    assert has_content?(I18n.t('timer_sessions.timer.cancel'))
+    
+    find('[data-name="timer-cancel"]', wait: 5).click
+    page.driver.browser.switch_to.alert.accept
+    
+    assert current_url.include?("filter%5Bmin_date%5D=#{filter_date}")
+    assert current_url.include?("filter%5Bmax_date%5D=#{current_date}")
+  end
 end

--- a/test/system/timer_sessions_management_test.rb
+++ b/test/system/timer_sessions_management_test.rb
@@ -81,4 +81,22 @@ class TimerSessionsManagementTest < ApplicationSystemTestCase
     click_button I18n.t('timer_sessions.work_report_query.buttons.submit')
     assert has_content?(I18n.t(:label_spent_time))
   end
+  
+  test 'preserves filter parameters when updating a timer session' do
+    filter_date = 1.week.ago.strftime('%Y-%m-%d')
+    current_date = Date.today.strftime('%Y-%m-%d')
+    
+    visit timer_sessions_path(filter: { min_date: filter_date, max_date: current_date })
+    
+    find('[data-timer-session-edit-button]', match: :first).click
+    assert has_content?(I18n.t('timer_sessions.edit.title'))
+    
+    within '.edit-modal' do
+      fill_in TimerSession.human_attribute_name(:comments), with: 'Updated with filters'
+      find('[data-modal-update-button]', match: :first).click
+    end
+    
+    assert current_url.include?("filter%5Bmin_date%5D=#{filter_date}")
+    assert current_url.include?("filter%5Bmax_date%5D=#{current_date}")
+  end
 end

--- a/test/system/timer_sessions_management_test.rb
+++ b/test/system/timer_sessions_management_test.rb
@@ -81,21 +81,21 @@ class TimerSessionsManagementTest < ApplicationSystemTestCase
     click_button I18n.t('timer_sessions.work_report_query.buttons.submit')
     assert has_content?(I18n.t(:label_spent_time))
   end
-  
+
   test 'preserves filter parameters when updating a timer session' do
     filter_date = 1.week.ago.strftime('%Y-%m-%d')
     current_date = Date.today.strftime('%Y-%m-%d')
-    
+
     visit timer_sessions_path(filter: { min_date: filter_date, max_date: current_date })
-    
+
     find('[data-timer-session-edit-button]', match: :first).click
     assert has_content?(I18n.t('timer_sessions.edit.title'))
-    
+
     within '.edit-modal' do
       fill_in TimerSession.human_attribute_name(:comments), with: 'Updated with filters'
       find('[data-modal-update-button]', match: :first).click
     end
-    
+
     assert current_url.include?("filter%5Bmin_date%5D=#{filter_date}")
     assert current_url.include?("filter%5Bmax_date%5D=#{current_date}")
   end


### PR DESCRIPTION
TICKET-19656

Previously if you had a filter setup for tracky and you were to submit or update a timer session, the filters would reset because the update action would redirect you to `/timer_sessions` without respecting url params.

This should be fixed now.