### PR TITLE
Move subject after issue id

### DIFF
--- a/app/helpers/timer_sessions_helper.rb
+++ b/app/helpers/timer_sessions_helper.rb
@@ -64,7 +64,7 @@ module TimerSessionsHelper
   end
 
   def issue_identifier(issue)
-    "[#{issue.project.name}] #{issue.id}"
+    "#{issue.id} #{issue.project.name}"
   end
 
   def truncated_subject(subject)

--- a/test/unit/timer_sessions_helper_test.rb
+++ b/test/unit/timer_sessions_helper_test.rb
@@ -44,6 +44,6 @@ class TimerSessionsHelperTest < ActionView::TestCase
   end
 
   test '#issue_link_list' do
-    assert_equal ['<a href="/issues/1">[eCookbook] 1: Cannot print recipes</a>'], issue_link_list([Issue.first])
+    assert_equal ['<a href="/issues/1">1 eCookbook: Cannot print recipes</a>'], issue_link_list([Issue.first])
   end
 end


### PR DESCRIPTION
TICKET-19656

ideally, the subject should be on a separate column, but for now this is already better