### PR TITLE
Handle blank issue inputs

### DIFF
--- a/app/controllers/timer_sessions_controller.rb
+++ b/app/controllers/timer_sessions_controller.rb
@@ -3,8 +3,7 @@
 class TimerSessionsController < TrackyController
   def index
     @timer_sessions_in_range = TimerSession.includes(:time_entries, :timer_session_time_entries, issues: :project)
-                                           .finished
-                                           .created_by(User.current)
+                                           .finished.created_by(User.current)
     @non_matching_timer_session_ids = TimeDiscrepancyLoader.uneven_timer_session_ids(@timer_sessions_in_range)
     set_timer_sessions
     @timer_offset = offset_for_time_zone
@@ -25,10 +24,7 @@ class TimerSessionsController < TrackyController
 
   def rebalance
     @timer_session = user_scoped_timer_session(params[:id])
-    TimeRebalancer.new(
-      @timer_session.relevant_issues.map(&:id),
-      @timer_session
-    ).force_rebalance
+    TimeRebalancer.new(@timer_session.relevant_issues.map(&:id), @timer_session).force_rebalance
     flash[:notice] = l(:notice_successful_update)
     redirect_to timer_sessions_path
   end
@@ -55,8 +51,7 @@ class TimerSessionsController < TrackyController
     timer_session_template = user_scoped_timer_session(params[:id])
     linked_issues = timer_session_template.relevant_issues
     new_timer_session = timer_session_template.dup
-    new_timer_session.update(timer_end: nil,
-                             finished: false,
+    new_timer_session.update(timer_end: nil, finished: false,
                              timer_start: (User.current.time_zone || Time.zone).now.asctime)
     IssueConnector.new(linked_issues.map(&:id) || [], new_timer_session).run
     redirect_to timer_sessions_path
@@ -64,19 +59,10 @@ class TimerSessionsController < TrackyController
 
   def update
     @timer_session = user_scoped_timer_session(params[:id])
-    if @timer_session.update(timer_session_update_params)
-      if issue_selection_submitted? && selected_issue_ids.blank?
-        @timer_session.errors.add(:issue_id, :no_selection)
-        return render_js :update
-      end
+    return render_js(:update) unless @timer_session.update(timer_session_update_params)
+    return render_no_selection_error if issue_selection_submitted? && selected_issue_ids.blank?
 
-      TimeRebalancer.new(selected_issue_ids || @timer_session.relevant_issues.map(&:id),
-                         @timer_session).rebalance_entries
-      flash[:notice] = l(:notice_successful_update)
-      render_js(@timer_session.valid? ? :update_redirect : :update)
-    else
-      render_js :update
-    end
+    render_rebalanced_update
   end
 
   private
@@ -100,27 +86,33 @@ class TimerSessionsController < TrackyController
     TimerSession.where(user: User.current).find(id)
   end
 
-  def timer_session_params
-    params.require(:timer_session).permit(:comments,
-                                          :timer_start,
-                                          :timer_end,
-                                          :issue_id,
-                                          issue_ids: [])
-  end
-
-  def timer_session_update_params
-    timer_session_params.except(:issue_id, :issue_ids)
-  end
-
   def selected_issue_ids
     return timer_session_params[:issue_ids].reject(&:blank?) if timer_session_params.key?(:issue_ids)
-    return Array.wrap(timer_session_params[:issue_id]).reject(&:blank?) if timer_session_params.key?(:issue_id)
 
-    nil
+    Array.wrap(timer_session_params[:issue_id]).reject(&:blank?) if timer_session_params.key?(:issue_id)
   end
 
   def issue_selection_submitted?
     timer_session_params.key?(:issue_ids) || timer_session_params.key?(:issue_id)
+  end
+
+  def render_no_selection_error
+    @timer_session.errors.add(:issue_id, :no_selection)
+    render_js :update
+  end
+
+  def render_rebalanced_update
+    TimeRebalancer.new(selected_issue_ids || @timer_session.relevant_issues.map(&:id), @timer_session).rebalance_entries
+    flash[:notice] = l(:notice_successful_update)
+    render_js(@timer_session.valid? ? :update_redirect : :update)
+  end
+
+  def timer_session_params
+    params.require(:timer_session).permit(:comments, :timer_start, :timer_end, :issue_id, issue_ids: [])
+  end
+
+  def timer_session_update_params
+    timer_session_params.except(:issue_id, :issue_ids)
   end
 
   def report_query_params

--- a/app/controllers/timer_sessions_controller.rb
+++ b/app/controllers/timer_sessions_controller.rb
@@ -64,8 +64,13 @@ class TimerSessionsController < TrackyController
 
   def update
     @timer_session = user_scoped_timer_session(params[:id])
-    if @timer_session.update(timer_session_params)
-      TimeRebalancer.new(timer_session_params[:issue_ids],
+    if @timer_session.update(timer_session_update_params)
+      if issue_selection_submitted? && selected_issue_ids.blank?
+        @timer_session.errors.add(:issue_id, :no_selection)
+        return render_js :update
+      end
+
+      TimeRebalancer.new(selected_issue_ids || @timer_session.relevant_issues.map(&:id),
                          @timer_session).rebalance_entries
       flash[:notice] = l(:notice_successful_update)
       render_js(@timer_session.valid? ? :update_redirect : :update)
@@ -99,7 +104,23 @@ class TimerSessionsController < TrackyController
     params.require(:timer_session).permit(:comments,
                                           :timer_start,
                                           :timer_end,
+                                          :issue_id,
                                           issue_ids: [])
+  end
+
+  def timer_session_update_params
+    timer_session_params.except(:issue_id, :issue_ids)
+  end
+
+  def selected_issue_ids
+    return timer_session_params[:issue_ids].reject(&:blank?) if timer_session_params.key?(:issue_ids)
+    return Array.wrap(timer_session_params[:issue_id]).reject(&:blank?) if timer_session_params.key?(:issue_id)
+
+    nil
+  end
+
+  def issue_selection_submitted?
+    timer_session_params.key?(:issue_ids) || timer_session_params.key?(:issue_id)
   end
 
   def report_query_params

--- a/app/controllers/timer_sessions_controller.rb
+++ b/app/controllers/timer_sessions_controller.rb
@@ -59,10 +59,14 @@ class TimerSessionsController < TrackyController
 
   def update
     @timer_session = user_scoped_timer_session(params[:id])
-    return render_js(:update) unless @timer_session.update(timer_session_update_params)
-    return render_no_selection_error if issue_selection_submitted? && selected_issue_ids.blank?
 
-    render_rebalanced_update
+    if @timer_session.update(timer_session_update_params)
+      TimeRebalancer.new(selected_issue_ids || @timer_session.relevant_issues.map(&:id), @timer_session).rebalance_entries
+      flash[:notice] = l(:notice_successful_update)
+      render_js(:update_redirect)
+    else
+      render_js :update
+    end
   end
 
   private
@@ -90,21 +94,6 @@ class TimerSessionsController < TrackyController
     return timer_session_params[:issue_ids].reject(&:blank?) if timer_session_params.key?(:issue_ids)
 
     Array.wrap(timer_session_params[:issue_id]).reject(&:blank?) if timer_session_params.key?(:issue_id)
-  end
-
-  def issue_selection_submitted?
-    timer_session_params.key?(:issue_ids) || timer_session_params.key?(:issue_id)
-  end
-
-  def render_no_selection_error
-    @timer_session.errors.add(:issue_id, :no_selection)
-    render_js :update
-  end
-
-  def render_rebalanced_update
-    TimeRebalancer.new(selected_issue_ids || @timer_session.relevant_issues.map(&:id), @timer_session).rebalance_entries
-    flash[:notice] = l(:notice_successful_update)
-    render_js(@timer_session.valid? ? :update_redirect : :update)
   end
 
   def timer_session_params

--- a/app/controllers/timer_sessions_controller.rb
+++ b/app/controllers/timer_sessions_controller.rb
@@ -61,7 +61,8 @@ class TimerSessionsController < TrackyController
     @timer_session = user_scoped_timer_session(params[:id])
 
     if @timer_session.update(timer_session_update_params)
-      TimeRebalancer.new(selected_issue_ids || @timer_session.relevant_issues.map(&:id), @timer_session).rebalance_entries
+      TimeRebalancer.new(selected_issue_ids || @timer_session.relevant_issues.map(&:id), @timer_session)
+                    .rebalance_entries
       flash[:notice] = l(:notice_successful_update)
       render_js(:update_redirect)
     else

--- a/app/models/finished_timer_session_validator.rb
+++ b/app/models/finished_timer_session_validator.rb
@@ -31,7 +31,7 @@ class FinishedTimerSessionValidator < ActiveModel::Validator
 
   def validate_issues_selected
     @record.errors.add(:issue_id, :no_selection) if @record.issues.blank?
-    @record.errors.add(:issue_id, :no_selection) if @record.issues.any? { it.blank? }
+    @record.errors.add(:issue_id, :no_selection) if @record.issues.any? { |i| i.blank? }
   end
 
   def validate_minimal_duration

--- a/app/models/finished_timer_session_validator.rb
+++ b/app/models/finished_timer_session_validator.rb
@@ -31,7 +31,7 @@ class FinishedTimerSessionValidator < ActiveModel::Validator
 
   def validate_issues_selected
     @record.errors.add(:issue_id, :no_selection) if @record.issues.blank?
-    @record.errors.add(:issue_id, :no_selection) if @record.issues.any? { |i| i.blank? }
+    @record.errors.add(:issue_id, :no_selection) if @record.issues.any?(&:blank?)
   end
 
   def validate_minimal_duration

--- a/app/models/finished_timer_session_validator.rb
+++ b/app/models/finished_timer_session_validator.rb
@@ -30,7 +30,8 @@ class FinishedTimerSessionValidator < ActiveModel::Validator
   end
 
   def validate_issues_selected
-    @record.errors.add(:issue_id, :no_selection) if @record.issues.none?
+    @record.errors.add(:issue_id, :no_selection) if @record.issues.blank?
+    @record.errors.add(:issue_id, :no_selection) if @record.issues.any? { it.blank? }
   end
 
   def validate_minimal_duration

--- a/app/services/time_rebalancer.rb
+++ b/app/services/time_rebalancer.rb
@@ -29,6 +29,7 @@ class TimeRebalancer
 
   def validate
     @timer_session.errors.add(:issue_id, :no_selection) if @issues.blank?
+    @timer_session.errors.add(:issue_id, :no_selection) if @issues.any? { it.blank? }
   end
 
   def handle_issues_changed

--- a/app/services/time_rebalancer.rb
+++ b/app/services/time_rebalancer.rb
@@ -2,13 +2,14 @@
 
 class TimeRebalancer
   def initialize(issues, timer_session)
-    @issues = (issues || []).map(&:to_i)
+    @issues = Array.wrap(issues).reject(&:blank?).map(&:to_i).uniq
     @issue_ids = timer_session.relevant_issues.map(&:id).map(&:to_i)
     @timer_session = timer_session
     validate
   end
 
   def rebalance_entries
+    return if @issues.blank?
     return unless @timer_session.valid?
 
     if issues_changed?

--- a/app/services/time_rebalancer.rb
+++ b/app/services/time_rebalancer.rb
@@ -29,7 +29,7 @@ class TimeRebalancer
 
   def validate
     @timer_session.errors.add(:issue_id, :no_selection) if @issues.blank?
-    @timer_session.errors.add(:issue_id, :no_selection) if @issues.any? { |i| i.blank? }
+    @timer_session.errors.add(:issue_id, :no_selection) if @issues.any?(&:blank?)
   end
 
   def handle_issues_changed

--- a/app/services/time_rebalancer.rb
+++ b/app/services/time_rebalancer.rb
@@ -29,7 +29,7 @@ class TimeRebalancer
 
   def validate
     @timer_session.errors.add(:issue_id, :no_selection) if @issues.blank?
-    @timer_session.errors.add(:issue_id, :no_selection) if @issues.any? { it.blank? }
+    @timer_session.errors.add(:issue_id, :no_selection) if @issues.any? { |i| i.blank? }
   end
 
   def handle_issues_changed

--- a/app/views/timer_sessions/update.js.erb
+++ b/app/views/timer_sessions/update.js.erb
@@ -1,4 +1,4 @@
-<% @timer_session.validate %>
+<% @timer_session.validate if @timer_session.errors.empty? %>
 $('#ajax-modal').html(
   ("<%= j render 'edit_modal', timer_session: @timer_session %>")
 );

--- a/test/functional/timer_sessions_controller_test.rb
+++ b/test/functional/timer_sessions_controller_test.rb
@@ -19,10 +19,15 @@ class TimerSessionsControllerTest < ActionController::TestCase
 
   def setup
     @issue = Issue.find(1)
+    @other_issue = Issue.find(2)
     @time_entry = TimeEntry.find(1)
     @user = User.find(1)
     @timer_session = FactoryBot.create(:timer_session,
                                        user: @user)
+    TimerSessionIssue.create!(
+      issue: @issue,
+      timer_session_id: @timer_session.id
+    )
     TimerSessionTimeEntry.create!(
       time_entry: @time_entry,
       timer_session_id: @timer_session.id
@@ -69,6 +74,31 @@ class TimerSessionsControllerTest < ActionController::TestCase
 
     assert_response 200
     assert @timer_session.comments, 'NEW IPA TOPIC'
+  end
+
+  test 'update accepts singular issue_id param' do
+    put(:update, params: {
+          id: @timer_session.id,
+          timer_session: { comments: 'NEW IPA TOPIC', issue_id: @other_issue.id }
+        }, xhr: true)
+
+    assert_response 200
+    assert_empty assigns(:timer_session).errors[:issue_id]
+    assert_equal [@other_issue.id], @timer_session.reload.issue_ids
+  end
+
+  test 'update with explicit empty issue selection does not continue' do
+    original_issue_ids = @timer_session.issue_ids
+
+    put(:update, params: {
+          id: @timer_session.id,
+          timer_session: { comments: 'NEW IPA TOPIC', issue_ids: [''] }
+        }, xhr: true)
+
+    assert_response 200
+    assert_includes assigns(:timer_session).errors[:issue_id],
+                    I18n.t('activerecord.errors.models.timer_session.attributes.issue_id.no_selection', locale: :en)
+    assert_equal original_issue_ids, @timer_session.reload.issue_ids
   end
 
   test 'continue' do

--- a/test/functional/timer_sessions_controller_test.rb
+++ b/test/functional/timer_sessions_controller_test.rb
@@ -89,13 +89,36 @@ class TimerSessionsControllerTest < ActionController::TestCase
     assert_equal [@other_issue.id], @timer_session.reload.issue_ids
   end
 
-  test 'update with explicit empty issue selection does not continue' do
+  test 'update with empty string in issue array selection does not continue' do
     original_issue_ids = @timer_session.issue_ids
 
     put(:update, params: {
           id: @timer_session.id,
           timer_session: { comments: 'NEW IPA TOPIC', issue_ids: [''] }
         }, xhr: true)
+
+    timer_session = @controller.instance_variable_get(:@timer_session)
+
+    assert_response 200
+    assert_includes timer_session.errors[:issue_id],
+                    I18n.t('activerecord.errors.models.timer_session.attributes.issue_id.no_selection', locale: :en)
+    assert_equal original_issue_ids, @timer_session.reload.issue_ids
+  end
+
+  test 'update with an empty array as issue selection does not continue' do
+    original_issue_ids = @timer_session.issue_ids
+
+    put :update,
+        params: { id: @timer_session.id },
+        body: {
+          timer_session: {
+            comments: 'NEW IPA TOPIC',
+            issue_ids: []
+          }
+        }.to_json,
+        as: :json,
+        format: :js,
+        xhr: true
 
     timer_session = @controller.instance_variable_get(:@timer_session)
 

--- a/test/functional/timer_sessions_controller_test.rb
+++ b/test/functional/timer_sessions_controller_test.rb
@@ -82,8 +82,10 @@ class TimerSessionsControllerTest < ActionController::TestCase
           timer_session: { comments: 'NEW IPA TOPIC', issue_id: @other_issue.id }
         }, xhr: true)
 
+    timer_session = @controller.instance_variable_get(:@timer_session)
+
     assert_response 200
-    assert_empty assigns(:timer_session).errors[:issue_id]
+    assert_empty timer_session.errors[:issue_id]
     assert_equal [@other_issue.id], @timer_session.reload.issue_ids
   end
 
@@ -95,8 +97,10 @@ class TimerSessionsControllerTest < ActionController::TestCase
           timer_session: { comments: 'NEW IPA TOPIC', issue_ids: [''] }
         }, xhr: true)
 
+    timer_session = @controller.instance_variable_get(:@timer_session)
+
     assert_response 200
-    assert_includes assigns(:timer_session).errors[:issue_id],
+    assert_includes timer_session.errors[:issue_id],
                     I18n.t('activerecord.errors.models.timer_session.attributes.issue_id.no_selection', locale: :en)
     assert_equal original_issue_ids, @timer_session.reload.issue_ids
   end

--- a/test/unit/time_rebalancer_test.rb
+++ b/test/unit/time_rebalancer_test.rb
@@ -87,4 +87,14 @@ class TimeRebalancerTest < ActiveSupport::TestCase
     assert_equal 1, TimerSessionIssue.count
     assert_equal issue_id, @timer_session.issues.first.id
   end
+
+  test '#rebalance_entries - blank issue input adds no_selection error' do
+    original_issue_ids = @timer_session.issue_ids
+
+    TimeRebalancer.new([''], @timer_session).rebalance_entries
+
+    assert_includes @timer_session.errors[:issue_id],
+                    I18n.t('activerecord.errors.models.timer_session.attributes.issue_id.no_selection', locale: :en)
+    assert_equal original_issue_ids, @timer_session.reload.issue_ids
+  end
 end


### PR DESCRIPTION
TICKET-25430

We accepted an update with no selected issues, added a `no_selection` error too late, and then accidentally cleared that error during later validation.

After that, the flow continued into TimeSplitter with zero issues, so it divided by zero and produced Infinity, which later blew up on `.round`

  - The request sent `timer_session.issue_id`, but the update path only looked at `issue_ids`.
  - Empty issue selection was not rejected early enough.
  - Manual errors were being wiped by later `validate`/`valid?` calls.
  - Rebalancing still ran with an empty issue list.